### PR TITLE
Added strictSSL option

### DIFF
--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -414,7 +414,12 @@ removeCLI = (callback) ->
       callback()
 
 downloadFile = (url, outputFile, callback) ->
-  r = request(url)
+  options = {
+      certFile: atom.config.get('wakatime').certFile,
+      proxy: atom.config.get('wakatime').proxyString,
+      url: url
+  }
+  r = request(options)
   out = fs.createWriteStream(outputFile)
   r.pipe(out)
   r.on('end', ->

--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -415,8 +415,7 @@ removeCLI = (callback) ->
 
 downloadFile = (url, outputFile, callback) ->
   options = {
-      certFile: atom.config.get('wakatime').certFile,
-      proxy: atom.config.get('wakatime').proxyString,
+      strictSSL: false,
       url: url
   }
   r = request(options)

--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -415,7 +415,7 @@ removeCLI = (callback) ->
 
 downloadFile = (url, outputFile, callback) ->
   options = {
-      strictSSL: false,
+      strictSSL: atom.config.get('wakatime.strictSSL')
       url: url
   }
   r = request(options)

--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -362,8 +362,11 @@ isCLILatest = (callback) ->
   )
 
 getLatestCliVersion = (callback) ->
-  url = 'https://raw.githubusercontent.com/wakatime/wakatime/master/wakatime/__about__.py'
-  request.get(url, (error, response, body) ->
+  options = {
+      strictSSL: atom.config.get('wakatime.strictSSL')
+      url: 'https://raw.githubusercontent.com/wakatime/wakatime/master/wakatime/__about__.py'
+  }
+  request.get(options, (error, response, body) ->
     version = null
     if !error and response.statusCode == 200
       re = new RegExp(/__version_info__ = \('([0-9]+)', '([0-9]+)', '([0-9]+)'\)/g)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,14 @@
       "type": "boolean",
       "default": false,
       "order": 4
-    }
+    },
+    "strictSSL": {
+      "title": "Enable strictSSL",
+      "description": "Toggle strictssl",
+      "type":"boolean",
+      "default":true,
+      "order": 5
+      }
   },
   "consumedServices": {
     "status-bar": {

--- a/package.json
+++ b/package.json
@@ -35,26 +35,12 @@
       "default": true,
       "order": 3
     },
-    "proxyString": {
-        "title": "Proxy string",
-        "description": "Your proxy string <username:password@host:port>",
-        "type": "string",
-        "default": "",
-        "order": 4
-    },
-    "certFile": {
-        "title": "Path to certifcate file",
-        "description": "Add .crt file. Commomly used: ca-bundle.crt",
-        "type": "string",
-        "default": "",
-        "order": 5
-    },
     "debug": {
       "title": "Debug",
       "description": "Logs verbose debug messages to the Atom developer console and ~/.wakatime.log file.",
       "type": "boolean",
       "default": false,
-      "order": 6
+      "order": 4
     }
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,20 @@
       "default": true,
       "order": 3
     },
+    "proxyString": {
+        "title": "Proxy string",
+        "description": "Your proxy string <username:password@host:port>",
+        "type": "string",
+        "default": "",
+        "order": 4
+    },
+    "certFile": {
+        "title": "Path to certifcate file",
+        "description": "Add .crt file. Commomly used: ca-bundle.crt",
+        "type": "string",
+        "default": "",
+        "order": 5
+    },
     "debug": {
       "title": "Debug",
       "description": "Logs verbose debug messages to the Atom developer console and ~/.wakatime.log file.",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "description": "Logs verbose debug messages to the Atom developer console and ~/.wakatime.log file.",
       "type": "boolean",
       "default": false,
-      "order": 4
+      "order": 6
     }
   },
   "consumedServices": {


### PR DESCRIPTION
Added an option to disable strictSSL within Wakatime config, as it wasn't using Atom's config.

 It defaults to strictSSL enabled, as disabling does raise security concerns but it is Atom's recommended way of dealing with this.

This simply modifies the request string by adding in the required option