### PR TITLE
fix: also allow python rc

### DIFF
--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -326,7 +326,7 @@ isSupportedPythonVersion = (binary, versionString) ->
 
   anaconda = /continuum|anaconda/gi
   isAnaconda = not not anaconda.test(versionString)
-  re = /python\s+(\d+)\.(\d+)\.(\d+)\s/gi
+  /python\s+(\d+)\.(\d+)\.(\d+)([a-z0-9]+)?\s/gi
   ver = re.exec(versionString)
   if not ver?
     return isAnaconda

--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -326,7 +326,7 @@ isSupportedPythonVersion = (binary, versionString) ->
 
   anaconda = /continuum|anaconda/gi
   isAnaconda = not not anaconda.test(versionString)
-  /python\s+(\d+)\.(\d+)\.(\d+)([a-z0-9]+)?\s/gi
+  re = /python\s+(\d+)\.(\d+)\.(\d+)([a-z0-9]+)?\s/gi
   ver = re.exec(versionString)
   if not ver?
     return isAnaconda


### PR DESCRIPTION
This fixes an error with the latest python3 on ubuntu 19.10 being an RC