### PR TITLE
Replace hard-coded config file path with a configurable one.

### DIFF
--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -159,14 +159,14 @@ settingChangedHandler = (settings, initial) ->
   apiKey = settings.apikey
   if isValidApiKey(apiKey)
     atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
-    atom.config.set 'wakatime.apikey', 'Saved in your ~/.wakatime.cfg file'
+    atom.config.set 'wakatime.apikey', 'Saved in your ' + atom.config.get 'wakatime.configfile' + ' file'
     saveApiKey apiKey
   else if initial
     atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
     atom.config.set 'wakatime.apikey', 'Enter your api key...'
 
 saveApiKey = (apiKey) ->
-  configFile = path.join getUserHome(), '.wakatime.cfg'
+  configFile = path.join getUserHome(), atom.config.get 'wakatime.configfile'
   fs.readFile configFile, 'utf-8', (err, inp) ->
     if err?
       log.debug 'Error: could not read wakatime config file'
@@ -222,7 +222,7 @@ loadDependencies = ->
   ini = require 'ini'
 
 setupConfigs = ->
-  configFile = path.join getUserHome(), '.wakatime.cfg'
+  configFile = path.join getUserHome(), atom.config.get 'wakatime.configfile'
   fs.readFile configFile, 'utf-8', (err, configContent) ->
     if err?
       log.debug 'Error: could not read wakatime config file'
@@ -231,7 +231,7 @@ setupConfigs = ->
     commonConfigs = ini.decode configContent
     if commonConfigs? and commonConfigs.settings? and isValidApiKey(commonConfigs.settings.api_key)
       atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
-      atom.config.set 'wakatime.apikey', 'Saved in your ~/.wakatime.cfg file'
+      atom.config.set 'wakatime.apikey', 'Saved in your config file'
     else
       settingChangedHandler atom.config.get('wakatime'), true
 
@@ -522,7 +522,7 @@ sendHeartbeat = (file, lineno, isWrite) ->
 
       # fix for wakatime/atom-wakatime#65
       args.push('--config')
-      args.push(path.join getUserHome(), '.wakatime.cfg')
+      args.push(path.join getUserHome(), atom.config.get 'wakatime.configfile' )
 
       if atom.project.contains(currentFile)
         for rootDir in atom.project.rootDirectories
@@ -553,7 +553,7 @@ executeHeartbeatProcess = (python, args, tries) ->
           status = null
           title = 'WakaTime Offline, coding activity will sync when online.'
         else if proc.exitCode == 103
-          msg = 'An error occured while parsing ~/.wakatime.cfg. Check ~/.wakatime.log for more info.'
+          msg = 'An error occured while parsing ' + atom.config.get 'wakatime.configfile' + ' . Check ~/.wakatime.log for more info.'
           status = 'Error'
           title = msg
         else if proc.exitCode == 104
@@ -600,7 +600,7 @@ getToday = () ->
     if atom.config.get 'wakatime.disableSSLCertVerify'
       args.push('--no-ssl-verify')
     args.push('--config')
-    args.push(path.join getUserHome(), '.wakatime.cfg')
+    args.push(path.join getUserHome(), atom.config.get 'wakatime.configfile')
 
     try
       proc = child_process.execFile(python, args, (error, stdout, stderr) ->

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "git"
   ],
   "configSchema": {
+    "configfile": {
+      "title": "Config File Location",
+      "description": "The place of your config file relative to your home folder",
+      "type": "string",
+      "default": ".wakatime.cfg",
+      "order": 0
+    },
     "apikey": {
       "title": "Api Key",
       "description": "Your secret key from https://wakatime.com/settings.",


### PR DESCRIPTION
The new config option configfile defaults to the former hardcoded path
`~/.wakatime.cfg` so there should be no difference for users after updating.

This doesn't provide  a fix for #94 but it allows to change the config file location without requiring a symlink.