### PR TITLE
Properly load config from $WAKATIME_HOME/.wakatime.cfg

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Patches and Suggestions
 
 - Vernon Grant <vernongrantt@gmail.com>
 - Brad Zacher <brad.zacher@gmail.com>
+- Alexander Degenhart <ein.stein.chen@gmx.com>

--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -146,14 +146,14 @@ settingChangedHandler = (settings, initial) ->
   apiKey = settings.apikey
   if isValidApiKey(apiKey)
     atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
-    atom.config.set 'wakatime.apikey', 'Saved in your ~/.wakatime.cfg file'
+    atom.config.set 'wakatime.apikey', 'Saved in your $WAKATIME_HOME/.wakatime.cfg file'
     saveApiKey apiKey
   else if initial
     atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
     atom.config.set 'wakatime.apikey', 'Enter your api key...'
 
 saveApiKey = (apiKey) ->
-  configFile = path.join getUserHome(), '.wakatime.cfg'
+  configFile = path.join getWakatimeHome(), '.wakatime.cfg'
   fs.readFile configFile, 'utf-8', (err, inp) ->
     if err?
       log.debug 'Error: could not read wakatime config file'
@@ -194,8 +194,8 @@ saveApiKey = (apiKey) ->
         statusBarIcon?.setStatus('Error')
         statusBarIcon?.setTitle(msg)
 
-getUserHome = ->
-  process.env[if process.platform == 'win32' then 'USERPROFILE' else 'HOME'] || ''
+getWakatimeHome = ->
+  process.env['WAKATIME_HOME'] || process.env[if process.platform == 'win32' then 'USERPROFILE' else 'HOME'] || ''
 
 loadDependencies = ->
   fs = require 'fs'
@@ -207,7 +207,7 @@ loadDependencies = ->
   ini = require 'ini'
 
 setupConfigs = ->
-  configFile = path.join getUserHome(), '.wakatime.cfg'
+  configFile = path.join getWakatimeHome(), '.wakatime.cfg'
   fs.readFile configFile, 'utf-8', (err, configContent) ->
     if err?
       log.debug 'Error: could not read wakatime config file'
@@ -216,7 +216,7 @@ setupConfigs = ->
     commonConfigs = ini.decode configContent
     if commonConfigs? and commonConfigs.settings? and isValidApiKey(commonConfigs.settings.api_key)
       atom.config.set 'wakatime.apikey', '' # clear setting so it updates in UI
-      atom.config.set 'wakatime.apikey', 'Saved in your ~/.wakatime.cfg file'
+      atom.config.set 'wakatime.apikey', 'Saved in your $WAKATIME_HOME/.wakatime.cfg file'
     else
       settingChangedHandler atom.config.get('wakatime'), true
 
@@ -405,7 +405,7 @@ executeHeartbeatProcess = (binary, args, tries) ->
           status = null
           title = 'WakaTime Offline, coding activity will sync when online.'
         else if proc.exitCode == 103
-          msg = 'An error occured while parsing ~/.wakatime.cfg. Check ~/.wakatime.log for more info.'
+          msg = 'An error occured while parsing $WAKATIME_HOME/.wakatime.cfg. Check $WAKATIME_HOME/.wakatime.log for more info.'
           status = 'Error'
           title = msg
         else if proc.exitCode == 104
@@ -452,7 +452,7 @@ getToday = () ->
   if atom.config.get 'wakatime.disableSSLCertVerify'
     args.push('--no-ssl-verify')
   args.push('--config')
-  args.push(path.join getUserHome(), '.wakatime.cfg')
+  args.push(path.join getWakatimeHome(), '.wakatime.cfg')
 
   try
     proc = child_process.execFile(cliLocation(), args, (error, stdout, stderr) ->


### PR DESCRIPTION
This adapts the behaviour of this plugin to the one of the wakatime cli as documented in
https://github.com/wakatime/wakatime/blob/master/README.rst#configuring

As we fallback to the home directory if $WAKATIME_HOME is not present this is
not a backward incompatible change.

Fixes #94