### PR TITLE
fix version checking not work correctly

### DIFF
--- a/lib/wakatime.coffee
+++ b/lib/wakatime.coffee
@@ -268,7 +268,7 @@ isCLILatest = (callback) ->
   args = ['--version']
   child_process.execFile(cliLocation(), args, (error, stdout, stderr) ->
     if not error?
-      currentVersion = stderr.trim()
+      currentVersion = stdout.trim()
       log.debug 'Current wakatime-cli version is ' + currentVersion
       log.debug 'Checking for updates to wakatime-cli...'
       getLatestCliVersion((latestVersion) ->


### PR DESCRIPTION
## What is PR doing

Fix version check not work correctly issue, this fix #101.

## Why issue appears

Here the reason why appears this issue:

The python version wakatime-cli v13.0.7 (wakatime/wakatime@e6ece4076b55e6d1b86ffe1ee8b95d14efda846b) and older versions, which use a user defined `argparse.py` file to parse arguments `--version`, see [user defined argparse code 1](https://github.com/wakatime/wakatime/blob/e6ece4076b55e6d1b86ffe1ee8b95d14efda846b/wakatime/packages/argparse.py#L1046) and [user defined argparse code 2](https://github.com/wakatime/wakatime/blob/e6ece4076b55e6d1b86ffe1ee8b95d14efda846b/wakatime/packages/argparse.py#L2365).

And since commit wakatime/wakatime@4153545dfa372c366fd07ae5ae0228c1a7e6960d, drop support python older then 3.8, and drop bundled packages, use a CPython argparse to parse arguments, see [cpython argparse code](https://github.com/python/cpython/blob/4ddb2d73ac661af516a252fe697ec05e726b0f20/Lib/argparse.py#L1070).

The differences between two is the std device, `stderr` is used before, and `stdout` used after.

The bad thing was done when wakatime/wakatime@a78d65405833c0acb5959aea568062e97bdef31b pushed, it builds a binary standalone cli, and upload to file hosting, but shared a version with v13.0.7. The CI seems fail, but the cli file is successfully uploaded.

This causes atom plugin was broken since May 5. Maybe other plugins use the wakatime/wakatime also broken.

## Conclusion

Since versions after v13.0.7 (without v13.0.7), only support CPython v3.8, after that version, cli output version info to `stdout`.
The atom plugin will update wakatime cli every 24 hours, so this PR will not break any things.

When user updates their atom wakatime plugin, their time activity logging will become normal, older version atom-plugin with newer wakatime-cli may not work.

And should release a new version for wakatime/wakatime.