### PR TITLE
Add optional chaining operator to response

### DIFF
--- a/lib/wakatime.js
+++ b/lib/wakatime.js
@@ -326,7 +326,7 @@ function getLatestCliVersion(callback) {
           if (modified.value) opt['headers']['If-Modified-Since'] = modified.value;
           try {
             request.get(opt, (error, response, json) => {
-              if (!error && (response.statusCode == 200 || response.statusCode == 304)) {
+              if (!error && response && (response.statusCode == 200 || response.statusCode == 304)) {
                 log.debug(`GitHub API Response ${response.statusCode}`);
                 if (response.statusCode == 304) {
                   options.getSetting('internal', 'cli_version', (version) => {
@@ -347,7 +347,7 @@ function getLatestCliVersion(callback) {
                 callback(latestCliVersion);
                 return;
               } else {
-                log.warn(`GitHub API Response ${response.statusCode}: ${error}`);
+                log.warn(`GitHub API Response ${"statusCode" in response ? response.statusCode : ""}: ${error}`);
                 callback('');
               }
             });


### PR DESCRIPTION
This PR adds optional chaining operator to `response` in order to not throw any error when response is null.

Fixes https://github.com/wakatime/atom-wakatime/issues/110